### PR TITLE
Add --committish flag.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* Next Release
+
+  - Add `--committish` command line flag.
+
 * `1.0.1`_ (3-Jan-2015)
 
   - Switch from using drone.io to travis-ci.org

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -13,6 +13,11 @@ the metadata in-memory, this is only really useful in the same *setup.py*
 execution as a packaging command such as ``sdist`` or one of the ``bdist``
 variants.
 
+.. option:: -C, --committish
+
+   Include the abbreviated version of the most recent committish as
+   the local portion of the version number.
+
 .. option:: -V FILE, --version-file FILE
 
    Writes the local segment of the version to *FILE* in addition to

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -49,3 +49,10 @@ Development Release Segment
 ---------------------------
 This extension defines the development release segment as the number of
 commits since the last merge.
+
+Local Segment
+-------------
+This extension defines the local identifier as the first seven characters
+of the most recent commit.  The local identifier is only included if the
+``--committish`` flag is included and either the post or development 
+segment is defined.


### PR DESCRIPTION
This PR adds support for appending the current committish similar to what is done in `git describe --tags`.  The abbreviated committish is appending as a local version following a `+` sign.