### PR TITLE
Fix manifest

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* `1.1.1`_ (18-Aor-2017)
+
+  - Clean up *MANIFEST.in*
+
 * `1.1.0`_ (6-Jan-2015)
 
   - Add `--committish` command line flag.
@@ -17,3 +21,4 @@ Changelog
 .. _1.0.0: https://github.com/dave-shawley/setupext-gitversion/compare/0.0.0...1.0.0
 .. _1.0.1: https://github.com/dave-shawley/setupext-gitversion/compare/1.0.0...1.0.1
 .. _1.1.0: https://github.com/dave-shawley/setupext-gitversion/compare/1.0.1...1.1.0
+.. _1.1.1: https://github.com/dave-shawley/setupext-gitversion/compare/1.1.0...1.1.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-5, Dave Shawley
+Copyright (c) 2014-2017, Dave Shawley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,9 @@ include LICENSE
 include LOCAL-VERSION
 include .coveragerc
 include *requirements.txt
+include tests.py
 include tox.ini
-graft doc
-graft tests
+graft docs
 
 global-exclude __pycache__
 global-exclude *.pyc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ from setupext import gitversion
 
 
 project = 'Setupext: gitversion'
-copyright = '2014, Dave Shawley'
+copyright = '2014-2017, Dave Shawley'
 version = gitversion.__version__
 release = gitversion.__version__
 

--- a/setupext/gitversion.py
+++ b/setupext/gitversion.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma no cover
     pass
 
 
-version_info = (1, 1, 0)
+version_info = (1, 1, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 


### PR DESCRIPTION
There were some errant `graft` commands in the manifest that may be causing grief with some versions of pip.