### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,13 +118,13 @@ Ok... Where?
 .. _Local Version Label: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
 .. _pkg_resources: https://pythonhosted.org/setuptools/pkg_resources.html#getting-or-creating-distributions
 
-.. |Version| image:: https://pypip.in/version/setupext-gitversion/badge.svg
+.. |Version| image:: https://img.shields.io/pypi/v/setupext-gitversion.svg
    :target: https://pypi.python.org/pypi/setupext-gitversion
-.. |Downloads| image:: https://pypip.in/download/setupext-gitversion/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/setupext-gitversion.svg
    :target: https://pypi.python.org/pypi/setupext-gitversion
 .. |Status| image:: https://travis-ci.org/dave-shawley/setupext-gitversion.svg
    :target: https://travis-ci.org/dave-shawley/setupext-gitversion
-.. |License| image:: https://pypip.in/license/setupext-gitversion/badge.svg
+.. |License| image:: https://img.shields.io/pypi/l/setupext-gitversion.svg
    :target: http://opensource.org/licenses/BSD-3-Clause
 .. |Docs| image:: https://readthedocs.org/projects/setupext-gitversion/badge/?version=latest
    :target: https://setupext-gitversion.readthedocs.org/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20setupext-gitversion))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `setupext-gitversion`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.